### PR TITLE
Fix unwrapping of excerpt HTML

### DIFF
--- a/vitepress/.vitepress/theme/utils/frontmatter.js
+++ b/vitepress/.vitepress/theme/utils/frontmatter.js
@@ -3,19 +3,19 @@ const EMPTY_LINK_SELECTOR = 'a[href="./.html"]'
 
 /**
  * Turn excerpt into a proper link to be used in an index.
- * @param {import('vitepress').ContentData} note
+ * @param {import('vitepress').ContentData} post
  */
-export const excerptToLink = note => {
-  if (!note.frontmatter.excerpt) { return }
+export const excerptToLink = post => {
+  if (!post.frontmatter.excerpt || post.excerptTransformed) { return }
 
-  const $body = parser.parseFromString(note.frontmatter.excerpt, 'text/html').body
-  const $linkToNote = $body.querySelector(EMPTY_LINK_SELECTOR)
+  const $body = parser.parseFromString(post.frontmatter.excerpt, 'text/html').body
+  const $linkToPost = $body.querySelector(EMPTY_LINK_SELECTOR)
 
   // Add missing `href`, or use title as link add missing link.
-  if ($linkToNote) {
-    $linkToNote.href = note.url
+  if ($linkToPost) {
+    $linkToPost.href = post.url
   } else {
-    $body.innerHTML = `<p><a href="${note.url}">${$body.children[0].innerHTML}</a></p>`
+    $body.innerHTML = `<p><a href="${post.url}">${$body.children[0].innerHTML}</a></p>`
   }
 
   /**
@@ -23,5 +23,6 @@ export const excerptToLink = note => {
    * if Vue could insert raw (unescaped) HTML like Laravel {{! htmlStr !}}.
    * That is why we wrapped the link by a `<p>` in a previous condition.
    */
-  note.frontmatter.excerpt = $body.children[0].innerHTML
+  post.frontmatter.excerpt = $body.children[0].innerHTML
+  post.excerptTransformed = true
 }


### PR DESCRIPTION
Was unwrapping the excerpt HTML node by 1 level at each navigation to the index (due to transforming it on mount).