### PR TITLE
Stick to system color scheme for now

### DIFF
--- a/vitepress/.vitepress/config.mjs
+++ b/vitepress/.vitepress/config.mjs
@@ -59,6 +59,8 @@ export default defineConfig({
     '<img class="visually-hidden" src="https://matomo.mehdi.cc/piwik.php?idsite=4&amp;rec=1" style="border:0" alt=""></body>\n</html>'
   ),
 
+  appearance: 'force-auto',
+
   themeConfig: {
     // https://vitepress.dev/reference/default-theme-config
     nav: [

--- a/vitepress/.vitepress/theme/index.js
+++ b/vitepress/.vitepress/theme/index.js
@@ -10,5 +10,5 @@ export default {
     app.component('datetime', Datetime)
     app.component('duration', Duration)
     app.component('tags', Tags)
-  }
+  },
 }


### PR DESCRIPTION
I don’t like the 2-states (instead of 3-states) current one.

Theme selectors should include light, dark and system (auto), otherwise their behavior is misleading when they have some sort of _auto_.