### PR TITLE
Remove Matomo script

### DIFF
--- a/vitepress/.vitepress/config.mjs
+++ b/vitepress/.vitepress/config.mjs
@@ -54,11 +54,11 @@ export default defineConfig({
     ]
   },
 
-  // add temporary stupid tracking
-  transformHtml: async code => code.replace(
-    '\n  </body>\n</html>',
-    '<img class="visually-hidden" src="https://matomo.mehdi.cc/piwik.php?idsite=4&amp;rec=1" style="border:0" alt=""></body>\n</html>'
-  ),
+  // // add temporary stupid tracking - commented and kept for faster further reuse
+  // transformHtml: async code => code.replace(
+  //   '\n  </body>\n</html>',
+  //   '<img class="visually-hidden" src="https://matomo.mehdi.cc/piwik.php?idsite=4&amp;rec=1" style="border:0" alt=""></body>\n</html>'
+  // ),
 
   appearance: 'force-auto',
 


### PR DESCRIPTION
The Matomo is already unplugged anyway.

## Checklist

- [x] I’m aware of the [contributing guidelines](https://github.com/meduzen/blog/blob/main/CONTRIBUTING.md) and [code of conduct](https://github.com/meduzen/blog/blob/main/CODE_OF_CONDUCT.md).
- [x] I’ve checked if [`size-limit` config](https://github.com/meduzen/blog/blob/main/.size-limit.json) or [Lychee ignore file](https://github.com/meduzen/blog/blob/main/.lycheeignore) should be updated.

---
